### PR TITLE
Statsmodels required only for estimate EMOS

### DIFF
--- a/envs/environment_py37_iris30.yml
+++ b/envs/environment_py37_iris30.yml
@@ -21,10 +21,10 @@ dependencies:
   - scipy=1.6
   - sigtools
   - sphinx
-  - statsmodels
   # Optional
   - numba
   - pysteps=1.4.1
+  - statsmodels
   - timezonefinder=4.1.0
   # Development
   - astroid

--- a/envs/environment_py38_iris30.yml
+++ b/envs/environment_py38_iris30.yml
@@ -21,11 +21,7 @@ dependencies:
   - scipy=1.6
   - sigtools
   - sphinx
-  - statsmodels
   # Optional
-  - numba
-  - pysteps=1.4.1
-  - timezonefinder=4.1.0
   # Development
   - astroid
   - bandit

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -994,6 +994,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             Order of coefficients is [alpha, beta, gamma, delta].
         """
         import statsmodels.api as sm
+
         default_initial_guess = (
             self.use_default_initial_guess
             or np.any(np.isnan(truths))

--- a/improver/calibration/ensemble_calibration.py
+++ b/improver/calibration/ensemble_calibration.py
@@ -42,7 +42,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import iris
 import numpy as np
-import statsmodels.api as sm
 from cf_units import Unit
 from iris.coords import Coord
 from iris.cube import Cube, CubeList
@@ -994,6 +993,7 @@ class EstimateCoefficientsForEnsembleCalibration(BasePlugin):
             List of coefficients to be used as initial guess.
             Order of coefficients is [alpha, beta, gamma, delta].
         """
+        import statsmodels.api as sm
         default_initial_guess = (
             self.use_default_initial_guess
             or np.any(np.isnan(truths))

--- a/improver_tests/acceptance/test_estimate_emos_coefficients.py
+++ b/improver_tests/acceptance/test_estimate_emos_coefficients.py
@@ -44,6 +44,8 @@ pytestmark = [pytest.mark.acc, acc.skip_if_kgo_missing]
 CLI = acc.cli_name_with_dashes(__file__)
 run_cli = acc.run_cli(CLI)
 
+pytest.importorskip("statsmodels")
+
 # The EMOS estimation tolerance is defined in units of the variable being
 # calibrated - not in terms of the EMOS coefficients produced by
 # estimate-emos-coefficients and compared against KGOs here.

--- a/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
+++ b/improver_tests/calibration/ensemble_calibration/test_EstimateCoefficientsForEnsembleCalibration.py
@@ -40,6 +40,7 @@ from functools import partial
 
 import iris
 import numpy as np
+import pytest
 from iris.tests import IrisTest
 
 from improver.calibration.ensemble_calibration import (
@@ -479,6 +480,7 @@ class Test_compute_initial_guess(IrisTest):
         halo surrounding the original data.
         Set up expected results for different situations.
         """
+        pytest.importorskip("statsmodels")
         self.distribution = "norm"
         self.desired_units = "degreesC"
         self.predictor = "mean"
@@ -812,6 +814,7 @@ class Test_process(
     @ManageWarnings(ignored_messages=IGNORED_MESSAGES, warning_types=WARNING_TYPES)
     def setUp(self):
         """Set up multiple cubes for testing."""
+        pytest.importorskip("statsmodels")
         super().setUp()
         self.distribution = "norm"
 


### PR DESCRIPTION
Change tests and code to make the statsmodels library only required for use of estimate EMOS functionality.

- Move import inside function where it is used
- Skip relevant unit and acceptance tests where statsmodels is not available
- Remove statsmodels (and some other optional libraries) from the py38 environment

Related to metoppv/improver#1563
